### PR TITLE
fix(commitstrip): decode html entities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3055,6 +3055,11 @@
         "whatwg-encoding": "^1.0.5"
       }
     },
+    "html-entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.1.1.tgz",
+      "integrity": "sha512-HjNLgm9Ba8zKd6NDMkXa0mMPn3eDUxOUnEIm/qy2Rm6rnqRHgI9DpMYIv1Fndu8haUmfMQHNYNrlNKmdU8GMnQ=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^8.2.0",
     "emoji-regex": "^9.2.2",
     "got": "^11.8.2",
+    "html-entities": "^2.1.1",
     "make-promises-safe": "^5.1.0",
     "pino": "^6.11.1"
   },

--- a/src/crons/CommitStrip.ts
+++ b/src/crons/CommitStrip.ts
@@ -1,5 +1,6 @@
 import { MessageEmbed } from 'discord.js';
 import got from 'got';
+import { decode } from 'html-entities';
 
 import { Cron, findTextChannelByName } from '../framework';
 
@@ -22,8 +23,10 @@ export default new Cron({
     }
 
     await channel.send(
-      `${latestCommitStrip.title} - ${latestCommitStrip.link}`,
-      new MessageEmbed({ image: { url: latestCommitStrip.imageUrl } }),
+      new MessageEmbed()
+        .setTitle(latestCommitStrip.title)
+        .setURL(latestCommitStrip.link)
+        .setImage(latestCommitStrip.imageUrl),
     );
   },
 });
@@ -107,7 +110,8 @@ async function getRecentCommitStrip(now: Date): Promise<CommitStrip | null> {
     id: strip.id,
     date: stripDate,
     link: strip.link,
-    title: strip.title.rendered,
+    // Sometimes, the title can contain HTML Entities, e.g. "Pendant ce temps, sur Mars #16 &#8211; Vivement 2028"
+    title: decode(strip.title.rendered, { level: 'html5', scope: 'strict' }),
     imageUrl: urlMatch[1],
   };
 }


### PR DESCRIPTION
Sometimes, the commit strip's title contains html entities.
Now, these entities are decoded.
Moreover, the style of the message has been improved.
![image](https://user-images.githubusercontent.com/48163546/112036912-7363fd80-8b41-11eb-9b7a-c71a56645de3.png)
