### PR TITLE
fix: improve format checker logs

### DIFF
--- a/src/framework/Cron.ts
+++ b/src/framework/Cron.ts
@@ -55,7 +55,7 @@ export class Cron extends Base {
     const logger = bot.logger.child({
       id: randomUUID(),
       type: 'Cron',
-      name: this.name,
+      cronName: this.name,
     });
     try {
       logger.debug('execute cron handler');

--- a/src/framework/FormatChecker.ts
+++ b/src/framework/FormatChecker.ts
@@ -57,7 +57,7 @@ export class FormatChecker extends Base {
     const { cleanContent, author } = message;
 
     logger.info(
-      { username: author.username, tag: author.tag, cleanContent },
+      { userId: author.id, userTag: author.tag, cleanContent },
       'Detected bad message format',
     );
 
@@ -84,8 +84,9 @@ export class FormatChecker extends Base {
       if (err.code !== 50007 /* Cannot send messages to this user */) {
         logger.error(
           err,
-          'failed to send private message to user %s',
+          'failed to send private message to user %s (id: %s)',
           author.tag,
+          author.id,
         );
       }
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
- do not use "name" field with Pino (it is special, for the application name)
- log user's name and tag and message content
- do not log when failed to send private message because of privacy settings
