### PR TITLE
fix: malformed epic games thumbnails' url

### DIFF
--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -197,7 +197,7 @@ async function getOfferedGames(
         slugSlashIndex === -1 ? slug : slug.slice(0, slugSlashIndex)
       }`,
       thumbnail: encodeURI(
-        game.keyImages.find((image) => image.type === 'Thumbnail').url,
+        game.keyImages.find((image) => image.type === 'Thumbnail')!.url,
       ),
       originalPrice: game.price.totalPrice.fmtPrice.originalPrice,
       discountStartDate: new Date(discount.startDate),

--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -196,9 +196,9 @@ async function getOfferedGames(
       link: `https://www.epicgames.com/store/fr/p/${
         slugSlashIndex === -1 ? slug : slug.slice(0, slugSlashIndex)
       }`,
-      thumbnail:
-        game.keyImages.find((image) => image.type === 'Thumbnail')?.url ||
-        game.keyImages[0].url,
+      thumbnail: encodeURI(
+        game.keyImages.find((image) => image.type === 'Thumbnail').url,
+      ),
       originalPrice: game.price.totalPrice.fmtPrice.originalPrice,
       discountStartDate: new Date(discount.startDate),
       discountEndDate: new Date(discount.endDate),


### PR DESCRIPTION
Fixes
```js
DiscordAPIError: Invalid Form Body
embed.thumbnail.url: Not a well formed URL.
embeds[0].thumbnail.url: Not a well formed URL.
    at RequestHandler.execute (/app/node_modules/discord.js/src/rest/RequestHandler.js:154:13)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async RequestHandler.push (/app/node_modules/discord.js/src/rest/RequestHandler.js:39:14)
    at Cron.handle (/app/src/crons/EpicGames.ts:33:7)
    at Cron.executeJob (/app/src/framework/Cron.ts:64:7)
```