### PR TITLE
Feature/knex sqlite

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,4 @@ node_modules
 tests
 
 .env
+*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ build
 
 # optional IDE
 .idea
+
+# Project specific
+*.sqlite3

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,7 @@ RUN npm ci
 COPY . .
 RUN npm run build
 
-CMD [ "node", "build/src/bot.js" ]
+ENV NODE_ENV production
+RUN npm ci --omit=dev
+
+CMD [ "bash", "start.sh" ]

--- a/README.md
+++ b/README.md
@@ -11,13 +11,19 @@
 
 ### Préparation de l'environnement
 
-Installez les dépendances avec npm:
+Installez les dépendances avec npm :
 
 ```console
 npm ci
 ```
 
-Créez un fichier `.env` avec votre token de bot:
+Préparation de la base de donnée ([knex](https://knexjs.org/guide/migrations.html#migration-cli) - sqlite) :
+
+```console
+npx knex migrate:latest
+```
+
+Créez un fichier `.env` avec votre token de bot :
 
 ```env
 DISCORD_TOKEN=votretoken
@@ -102,4 +108,25 @@ export default new Cron({
     // Code exécuté selon le programme
   },
 });
+```
+
+#### Database
+
+On utilise `knex.js`.
+
+Pour créer une nouvelle migration : `npx knex migrate:make migration_name`
+Doc pour le SchemaBuilder : https://knexjs.org/guide/schema-builder.html
+
+Si besoin de stocker des settings basique, la table `kv` est disponible avec l'api `KeyValue` (proche d'une `Map`, mais qui requête la DB).
+
+Les clés doivent être des `string`, les valeurs peuvent être n'importe quoi, sachant que ce sera sérialisé / désérialisé de JSON (donc pas de données circulaires, pas de fonctions).
+
+```typescript
+import { KeyValue } from "#src/database/";
+
+await KeyValue.set('MyCron-LastRunResult', 'https://github.com/ES-Community/bot/issues/17');
+const myLastResult = await KeyValue.get('MyCron-LastRunResult');
+
+if (result === myLastResult) return;
+notify(result);
 ```

--- a/knexfile.js
+++ b/knexfile.js
@@ -8,20 +8,31 @@ module.exports = {
     client: 'better-sqlite3',
     connection: {
       filename: './dev.sqlite3'
-    }
+    },
+    useNullAsDefault: true
   },
 
   staging: {
     client: 'better-sqlite3',
     connection: {
       filename: './staging.sqlite3'
-    }
+    },
+    useNullAsDefault: true
   },
 
   production: {
     client: 'better-sqlite3',
     connection: {
       filename: './prod.sqlite3'
-    }
-  }
+    },
+    useNullAsDefault: true
+  },
+  
+  test: {
+    client: 'better-sqlite3',
+    connection: {
+      filename: './test.sqlite3'
+    },
+    useNullAsDefault: true
+  },
 };

--- a/knexfile.js
+++ b/knexfile.js
@@ -1,0 +1,27 @@
+// Update with your config settings.
+
+/**
+ * @type { Object.<string, import("knex").Knex.Config> }
+ */
+module.exports = {
+  development: {
+    client: 'better-sqlite3',
+    connection: {
+      filename: './dev.sqlite3'
+    }
+  },
+
+  staging: {
+    client: 'better-sqlite3',
+    connection: {
+      filename: './staging.sqlite3'
+    }
+  },
+
+  production: {
+    client: 'better-sqlite3',
+    connection: {
+      filename: './prod.sqlite3'
+    }
+  }
+};

--- a/migrations/20220916142133_InitDatabase.js
+++ b/migrations/20220916142133_InitDatabase.js
@@ -5,9 +5,9 @@
 exports.up = function(knex) {
   return knex.schema
     .createTable('kv', table => {
-      table.string('key').notNullable()
-      table.primary('key')
-      table.json('value')
+      table.string('key').notNullable();
+      table.primary('key');
+      table.json('value');
     });
 };
 
@@ -16,5 +16,5 @@ exports.up = function(knex) {
  * @returns { Promise<void> }
  */
 exports.down = function(knex) {
-  return knex.schema.dropTable('kv')
+  return knex.schema.dropTable('kv');
 };

--- a/migrations/20220916142133_InitDatabase.js
+++ b/migrations/20220916142133_InitDatabase.js
@@ -1,0 +1,20 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = function(knex) {
+  return knex.schema
+    .createTable('kv', table => {
+      table.string('key').notNullable()
+      table.primary('key')
+      table.json('value')
+    });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = function(knex) {
+  return knex.schema.dropTable('kv')
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,14 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "better-sqlite3": "^7.6.2",
         "cron": "^1.8.2",
         "discord.js": "^12.5.3",
         "dotenv": "^10.0.0",
         "emoji-regex": "^9.2.2",
         "got": "^11.8.2",
         "html-entities": "^2.3.2",
+        "knex": "^2.3.0",
         "node-html-parser": "^5.3.3",
         "pino": "^6.12.0"
       },
@@ -1977,6 +1979,35 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/better-sqlite3": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
+      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.0"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -1984,6 +2015,24 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/boolbase": {
@@ -2107,6 +2156,29 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -2212,6 +2284,11 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
     "node_modules/ci-info": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
@@ -2304,6 +2381,14 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/concat-map": {
@@ -2449,10 +2534,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2506,7 +2590,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -2540,6 +2623,14 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -2764,7 +2855,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -2993,6 +3083,14 @@
         "node": ">=4"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -3141,6 +3239,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
@@ -3247,6 +3353,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3310,6 +3421,11 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3333,8 +3449,7 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
@@ -3364,7 +3479,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3382,6 +3496,16 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/glob": {
       "version": "7.1.7",
@@ -3508,7 +3632,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -3630,6 +3753,25 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -3708,14 +3850,20 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/ini": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
-      "dev": true
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+    },
+    "node_modules/interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -3745,7 +3893,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
       "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
-      "dev": true,
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5036,6 +5183,69 @@
         "node": ">=6"
       }
     },
+    "node_modules/knex": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.3.0.tgz",
+      "integrity": "sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==",
+      "dependencies": {
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.5.0",
+        "rechoir": "^0.8.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.2",
+        "tildify": "2.0.0"
+      },
+      "bin": {
+        "knex": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependenciesMeta": {
+        "better-sqlite3": {
+          "optional": true
+        },
+        "mysql": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "pg-native": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        },
+        "tedious": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/knex/node_modules/colorette": {
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+    },
+    "node_modules/knex/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -5085,8 +5295,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
@@ -5118,7 +5327,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -5244,8 +5452,7 @@
     "node_modules/minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -5258,6 +5465,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "node_modules/moment": {
       "version": "2.29.1",
@@ -5290,14 +5502,29 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/node-abi": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
+      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.1",
@@ -5788,8 +6015,7 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -5799,6 +6025,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -5878,6 +6109,31 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/prelude-ls": {
@@ -6079,7 +6335,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -6094,7 +6349,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6109,7 +6363,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -6129,6 +6382,17 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "dependencies": {
+        "resolve": "^1.20.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/regexpp": {
@@ -6189,7 +6453,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -6298,8 +6561,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -6323,7 +6585,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -6386,6 +6647,49 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -6487,7 +6791,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -6496,7 +6799,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6657,6 +6959,40 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tarn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+      "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -6710,6 +7046,14 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "node_modules/tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.4",
@@ -6874,6 +7218,17 @@
       },
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tweetnacl": {
@@ -7063,8 +7418,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/v8-compile-cache": {
       "version": "2.3.0",
@@ -7286,8 +7640,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",
@@ -8845,11 +9198,43 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "better-sqlite3": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-7.6.2.tgz",
+      "integrity": "sha512-S5zIU1Hink2AH4xPsN0W43T1/AJ5jrPh7Oy07ocuW/AKYYY02GWzz9NH0nbSMn/gw6fDZ5jZ1QsHt1BXAwJ6Lg==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.0"
+      }
+    },
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
     },
     "boolbase": {
       "version": "1.0.0",
@@ -8946,6 +9331,15 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -9020,6 +9414,11 @@
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "ci-info": {
       "version": "3.2.0",
@@ -9098,6 +9497,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.0.tgz",
+      "integrity": "sha512-sRPT+umqkz90UA8M1yqYfnHlZA7fF6nSphDtxeywPZ49ysjxDQybzk13CL+mXekDRG92skbcqCLVovuCusNmFw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -9217,10 +9621,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-      "dev": true,
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "requires": {
         "ms": "2.1.2"
       }
@@ -9255,8 +9658,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -9279,6 +9681,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -9443,8 +9850,7 @@
     "escalade": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
-      "dev": true
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
     },
     "escape-goat": {
       "version": "2.1.1",
@@ -9610,6 +10016,11 @@
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
       "dev": true
     },
+    "esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
+    },
     "espree": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
@@ -9717,6 +10128,11 @@
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
       "dev": true
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
     "expect": {
       "version": "27.0.6",
       "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.6.tgz",
@@ -9807,6 +10223,11 @@
         "flat-cache": "^3.0.4"
       }
     },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -9858,6 +10279,11 @@
         "mime-types": "^2.1.12"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -9874,8 +10300,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -9898,8 +10323,7 @@
     "get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q=="
     },
     "get-stream": {
       "version": "5.2.0",
@@ -9908,6 +10332,16 @@
       "requires": {
         "pump": "^3.0.0"
       }
+    },
+    "getopts": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/getopts/-/getopts-2.3.0.tgz",
+      "integrity": "sha512-5eDf9fuSXwxBL6q5HX+dhDj+dslFGWzU5thZ9kNKUkcPtaPdatmUFKwHFrLb/uf/WpA4BHET+AX3Scl56cAjpA=="
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.1.7",
@@ -10000,7 +10434,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -10092,6 +10525,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -10149,14 +10587,17 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
-      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
-      "dev": true
+      "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ=="
+    },
+    "interpret": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+      "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -10180,7 +10621,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
       "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
-      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -11165,6 +11605,39 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "knex": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-2.3.0.tgz",
+      "integrity": "sha512-WMizPaq9wRMkfnwKXKXgBZeZFOSHGdtoSz5SaLAVNs3WRDfawt9O89T4XyH52PETxjV8/kRk0Yf+8WBEP/zbYw==",
+      "requires": {
+        "colorette": "2.0.19",
+        "commander": "^9.1.0",
+        "debug": "4.3.4",
+        "escalade": "^3.1.1",
+        "esm": "^3.2.25",
+        "get-package-type": "^0.1.0",
+        "getopts": "2.3.0",
+        "interpret": "^2.2.0",
+        "lodash": "^4.17.21",
+        "pg-connection-string": "2.5.0",
+        "rechoir": "^0.8.0",
+        "resolve-from": "^5.0.0",
+        "tarn": "^3.0.2",
+        "tildify": "2.0.0"
+      },
+      "dependencies": {
+        "colorette": {
+          "version": "2.0.19",
+          "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+          "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        }
+      }
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -11202,8 +11675,7 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -11232,7 +11704,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -11327,14 +11798,18 @@
     "minimist": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "moment": {
       "version": "2.29.1",
@@ -11358,14 +11833,26 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
     },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node-abi": {
+      "version": "3.24.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.24.0.tgz",
+      "integrity": "sha512-YPG3Co0luSu6GwOBsmIdGW6Wx0NyNDLg/hriIyDllVsNwnI6UeqaWShxC3lbH4LtEQUgoLP3XR1ndXiDAWvmRw==",
+      "requires": {
+        "semver": "^7.3.5"
+      }
     },
     "node-fetch": {
       "version": "2.6.1",
@@ -11739,14 +12226,18 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
       "dev": true
+    },
+    "pg-connection-string": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
+      "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
     "picomatch": {
       "version": "2.3.0",
@@ -11808,6 +12299,25 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
       }
     },
     "prelude-ls": {
@@ -11942,7 +12452,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11953,8 +12462,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -11968,7 +12476,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -11982,6 +12489,14 @@
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
+      }
+    },
+    "rechoir": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+      "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
+      "requires": {
+        "resolve": "^1.20.0"
       }
     },
     "regexpp": {
@@ -12024,7 +12539,6 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -12099,8 +12613,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -12121,7 +12634,6 @@
       "version": "7.3.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
       "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
       }
@@ -12168,6 +12680,21 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
     },
     "sisteransi": {
       "version": "1.0.5",
@@ -12253,7 +12780,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
       },
@@ -12261,8 +12787,7 @@
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         }
       }
     },
@@ -12381,6 +12906,34 @@
         }
       }
     },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "tarn": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.2.tgz",
+      "integrity": "sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ=="
+    },
     "term-size": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
@@ -12419,6 +12972,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-6.0.1.tgz",
       "integrity": "sha512-8hmiGIJMDlwjg7dlJ4yKGLK8EsYqKgPWbG3b4wjJddKNwc7N7Dpn08Df4szr/sZdMVeOstrdYSsqzX6BYbcB+w==",
       "dev": true
+    },
+    "tildify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tildify/-/tildify-2.0.0.tgz",
+      "integrity": "sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw=="
     },
     "tmpl": {
       "version": "1.0.4",
@@ -12525,6 +13083,14 @@
       "dev": true,
       "requires": {
         "tslib": "^1.8.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -12678,8 +13244,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "v8-compile-cache": {
       "version": "2.3.0",
@@ -12850,8 +13415,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
   },
   "homepage": "https://github.com/ES-Community/bot#readme",
   "dependencies": {
+    "better-sqlite3": "^7.6.2",
     "cron": "^1.8.2",
     "discord.js": "^12.5.3",
     "dotenv": "^10.0.0",
     "emoji-regex": "^9.2.2",
     "got": "^11.8.2",
     "html-entities": "^2.3.2",
+    "knex": "^2.3.0",
     "node-html-parser": "^5.3.3",
     "pino": "^6.12.0"
   },

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -27,27 +27,27 @@ export const KeyValue = {
       .then(values => values[0].key as number);
   },
 
-  keys(): Promise<Iterable<string>> {
-    return KeyValueStore<string>()
+  keys(): Promise<string[]> {
+    return KeyValueStore<string[]>()
       .select('key')
       .pluck('key');
   },
 
-  values(): Promise<Iterable<JSONTypes>> {
-    return KeyValueStore<JSONTypes>()
+  values(): Promise<JSONTypes[]> {
+    return KeyValueStore<JSONTypes[]>()
       .select('value')
       .pluck('value')
       .then(values => values.map((v: string) => JSON.parse(v)));
   },
 
-  entries(): Promise<Iterable<[string, JSONTypes]>> {
+  entries(): Promise<[string, JSONTypes][]> {
     return KeyValueStore<Iterable<IKeyValue>>()
       .select('key', 'value')
       .then(entries => entries.map((kv) => [kv.key, JSON.parse(kv.value)]));
   },
 
-  all(): Promise<Iterable<IKeyValue>> {
-    return KeyValueStore<Iterable<IKeyValue>>()
+  all(): Promise<IKeyValue[]> {
+    return KeyValueStore<IKeyValue[]>()
       .select('key', 'value')
       .then(items => {
         for (const item of items) {

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -3,8 +3,7 @@ import DB from "./db";
 type JSONScalar = boolean | number | string | null;
 type JSONKey = string | number;
 type JSONArray = (JSONScalar | JSONArray | JSONObject)[];
-type JSONObjectRecursive<A extends Record<JSONKey, JSONScalar | JSONArray>> = A | Record<JSONKey, A>;
-type JSONObject = JSONObjectRecursive<Record<JSONKey, JSONScalar | JSONArray>>
+type JSONObject = Record<string, any>;
 type JSONTypes = JSONScalar | JSONArray | JSONObject;
 
 export interface IKeyValue {
@@ -18,47 +17,77 @@ export const KeyValueStore = <U = never>() => DB<U>('kv');
 export const KeyValue = {
   length(): Promise<number> {
     return KeyValueStore<number>()
-      .count('key')
-      .pluck('key')
-      .first();
+      .count('key', {as: 'key'})
+      .then(values => values[0].key as number);
   },
-  
+
   keys(): Promise<Iterable<string>> {
     return KeyValueStore<string>()
       .select('key')
       .pluck('key');
   },
-  
+
   values(): Promise<Iterable<JSONTypes>> {
     return KeyValueStore<JSONTypes>()
       .select('value')
       .pluck('value')
       .then(values => values.map((v: string) => JSON.parse(v)));
   },
-  
+
   entries(): Promise<Iterable<[string, JSONTypes]>> {
     return KeyValueStore<Iterable<IKeyValue>>()
       .select('key', 'value')
-      .then(entries => entries.map((kv) => [kv.key, kv.value]));
+      .then(entries => entries.map((kv) => [kv.key, JSON.parse(kv.value)]));
   },
-  
+
   all(): Promise<Iterable<IKeyValue>> {
     return KeyValueStore<Iterable<IKeyValue>>()
-      .select('key', 'value');
+      .select('key', 'value')
+      .then(items => {
+        for (const item of items) {
+          item.value = JSON.parse(item.value);
+        }
+
+        return items;
+      });
   },
-  
-  async get(key: string): Promise<JSONTypes> {
-    const value = await KeyValueStore<string>().select('value').where('key', key).first();
-    
-    return JSON.parse(value);
+
+  async has(key: string): Promise<boolean> {
+    return KeyValueStore<string>()
+      .select('key')
+      .where('key', key)
+      .first()
+      .then(Boolean);
   },
-  
-  async set(key: string, value: JSONTypes): Promise<number[]> {
+
+  async get(key: string): Promise<JSONTypes | undefined> {
+    const item = await KeyValueStore<string>().select('value').where('key', key).first();
+    if (!item) return item;
+
+    return JSON.parse(item.value);
+  },
+
+  /// the number returned is the row id from sqlite
+  async set(key: string, value: JSONTypes): Promise<number> {
     return KeyValueStore<IKeyValue>().insert({
       key: key,
       value: JSON.stringify(value)
     })
       .onConflict('key')
-      .merge();
-  }
+      .merge()
+      .then(items => items[0]);
+  },
+
+  // Promise<number> is the number of row deleted
+  // it seems .returning is not supported for knex with sqlite,
+  // so we cannot return the row deleted
+  drop(key: string): Promise<number> {
+    return KeyValueStore()
+      .where('key', key)
+      .delete();
+  },
+
+  dropAll(): Promise<void> {
+    return KeyValueStore().truncate()
+  },
 }

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -10,6 +10,13 @@ export interface IKeyValue {
   value: JSONTypes;
 }
 
+export enum SearchFlag {
+  Exact = 0b00,
+  StartsWith = 0b01,
+  EndsWith = 0b10,
+  Contains = 0b11,
+}
+
 // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export const KeyValueStore = <U = never>() => DB<U>('kv');
 
@@ -82,7 +89,7 @@ export const KeyValue = {
    * @param likeKey - case-insensitive
    * @param flag - a 2 binary mask. 0b10 for left %, 0b01 for right %, 0b11 for both
    */
-  search(likeKey :string, flag = 0b11): Promise<IKeyValue[]> {
+  search(likeKey :string, flag: SearchFlag = SearchFlag.Contains): Promise<IKeyValue[]> {
     const left = (0b10 & flag) ? '%' : '';
     const right = (0b01 & flag) ? '%' : '';
 

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -14,7 +14,7 @@ export interface IKeyValue {
 export const KeyValueStore = <U = never>() => DB<U>('kv');
 
 export const KeyValue = {
-  length(): Promise<number> {
+  size(): Promise<number> {
     return KeyValueStore<number>()
       .count('key', {as: 'key'})
       .then(values => values[0].key as number);
@@ -80,13 +80,13 @@ export const KeyValue = {
   // Promise<number> is the number of row deleted
   // it seems .returning is not supported for knex with sqlite,
   // so we cannot return the row deleted
-  drop(key: string): Promise<number> {
+  delete(key: string): Promise<number> {
     return KeyValueStore()
       .where('key', key)
       .delete();
   },
 
-  dropAll(): Promise<void> {
+  clear(): Promise<void> {
     return KeyValueStore().truncate()
   },
 }

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -1,10 +1,9 @@
 import DB from "./db";
 
 type JSONScalar = boolean | number | string | null;
-type JSONKey = string | number;
-type JSONArray = (JSONScalar | JSONArray | JSONObject)[];
-type JSONObject = Record<string, any>;
-type JSONTypes = JSONScalar | JSONArray | JSONObject;
+type JSONTypes = JSONScalar | JSONObject | JSONArray;
+type JSONObject = { [member: string]: JSONTypes };
+type JSONArray = JSONTypes[];
 
 export interface IKeyValue {
   key: string;

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -1,0 +1,22 @@
+import DB from "./db";
+
+type JSONScalar = boolean | number | string | null;
+type JSONKey = string | number;
+type JSONArray = (JSONScalar | JSONArray | JSONObject)[];
+type JSONObjectRecursive<A extends Record<JSONKey, JSONScalar | JSONArray>> = A | Record<JSONKey, A>;
+type JSONObject = JSONObjectRecursive<Record<JSONKey, JSONScalar | JSONArray>>
+type JSONTypes = JSONScalar | JSONArray | JSONObject;
+
+export interface IKeyValue {
+  key: string;
+  value: Record<string | number, JSONTypes>;
+}
+
+export const KeyValueStore = () => DB('kv');
+
+export const KeyValue = {
+  get length(): Promise<number> {
+    return KeyValueStore().count('key').pluck('key')
+      .then(results => results[0]);
+  }
+}

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,7 +1,8 @@
-import knex from 'knex';
+import knex, { Knex } from 'knex';
 import * as Environments from '../../knexfile.js';
 
-const env = process.env.NODE_ENV || 'development'
+export const env = process.env.NODE_ENV || 'development';
+export const config: Knex.Config = Environments[env];
 
-export const DB = knex(Environments[env]);
+export const DB = knex(config);
 export default DB;

--- a/src/database/db.ts
+++ b/src/database/db.ts
@@ -1,0 +1,7 @@
+import knex from 'knex';
+import * as Environments from '../../knexfile.js';
+
+const env = process.env.NODE_ENV || 'development'
+
+export const DB = knex(Environments[env]);
+export default DB;

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,0 +1,1 @@
+export * from './db';

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -1,1 +1,2 @@
 export * from './db';
+export * from './KeyValue';

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+
+npx knex migrate:latest
+node build/src/bot.js

--- a/tests/database/KeyValue.spec.ts
+++ b/tests/database/KeyValue.spec.ts
@@ -13,7 +13,7 @@ afterAll(async () => {
 
 describe('Check emptiness', () => {
   test('KeyValue.length() === 0', async () => {
-    expect(await KeyValue.length()).toBe(0);
+    expect(await KeyValue.size()).toBe(0);
   });
 
   test('KeyValue.keys() === []', async () => {
@@ -209,7 +209,7 @@ describe('check getters when not empty', () => {
   });
 
   test('.length() === 3', async () => {
-    expect(await KeyValue.length()).toBe(3);
+    expect(await KeyValue.size()).toBe(3);
   });
 
   test('.keys()', async () => {
@@ -255,21 +255,21 @@ describe('check dropping', () => {
   });
 
   test('.drop() inexistant key', async () => {
-    expect(await KeyValue.drop("inexistant")).toBe(0);
+    expect(await KeyValue.delete("inexistant")).toBe(0);
   });
 
   test('.drop() existent key', async () => {
-    expect(await KeyValue.drop("key")).toEqual(1);
-    expect(await KeyValue.length()).toBe(2);
+    expect(await KeyValue.delete("key")).toEqual(1);
+    expect(await KeyValue.size()).toBe(2);
   });
 
   test('.drop() existent key with json', async () => {
-    expect(await KeyValue.drop("last-epic-slugs")).toEqual(1);
-    expect(await KeyValue.length()).toBe(2);
+    expect(await KeyValue.delete("last-epic-slugs")).toEqual(1);
+    expect(await KeyValue.size()).toBe(2);
   });
 
   test('.dropAll', async () => {
-    await KeyValue.dropAll();
-    expect(await KeyValue.length()).toBe(0);
+    await KeyValue.clear();
+    expect(await KeyValue.size()).toBe(0);
   });
 })

--- a/tests/database/KeyValue.spec.ts
+++ b/tests/database/KeyValue.spec.ts
@@ -1,0 +1,275 @@
+import type { Knex } from "knex";
+import fs from 'fs/promises';
+import { DB, config, KeyValue, KeyValueStore } from '#src/database';
+
+beforeAll(async () => {
+  await fs.rm((config.connection as Knex.Sqlite3ConnectionConfig).filename, {force: true});
+  await DB.migrate.latest();
+});
+
+afterAll(async () => {
+  await DB.destroy();
+})
+
+describe('Check emptiness', () => {
+  test('KeyValue.length() === 0', async () => {
+    expect(await KeyValue.length()).toBe(0);
+  });
+
+  test('KeyValue.keys() === []', async () => {
+    expect(await KeyValue.keys()).toEqual([]);
+  });
+
+  test('KeyValue.values() === []', async () => {
+    expect(await KeyValue.values()).toEqual([]);
+  });
+
+  test('KeyValue.entries() === []', async () => {
+    expect(await KeyValue.entries()).toEqual([]);
+  });
+
+  test('KeyValue.all() === []', async () => {
+    expect(await KeyValue.all()).toEqual([]);
+  });
+
+  test('KeyValue.has("donotexistkey") === false', async () => {
+    expect(await KeyValue.has("donotexistkey")).toEqual(false);
+  });
+
+  test('KeyValue.get("donotexistkey") === undefined', async () => {
+    expect(await KeyValue.get("donotexistkey")).toEqual(undefined);
+  });
+});
+
+describe('Check insertion', () => {
+  afterEach(async () => {
+    await KeyValueStore().truncate();
+  });
+
+  //
+  // check if add new row
+  //
+
+  test('KeyValue.set("key", "value") === 1', async () => {
+    const rowInserted = await KeyValue.set("key", "value");
+    expect(rowInserted).toBe(1);
+  });
+
+  test('KeyValue.has("key") === true', async () => {
+    await KeyValue.set("key", "value");
+    expect(await KeyValue.has('key')).toBe(true);
+  });
+
+  test('KeyValue.set("key", "value-b") === 1, when key already exist', async () => {
+    await KeyValue.set("key", "value-a");
+    const rowInserted = await KeyValue.set("key", "value-b");
+
+    expect(rowInserted).toBe(1);
+  });
+
+  test('KeyValue.set("key-2", "value-b") === 2, when key already exist', async () => {
+    await KeyValue.set("key-1", "value");
+    await KeyValue.set("key-2", "value");
+    const rowInserted = await KeyValue.set("key-2", "value-b");
+
+    expect(rowInserted).toBe(2);
+  });
+
+  //
+  // Check if value inserted is correct
+  //
+
+  test('KeyValue.get("key") === "value"', async () => {
+    await KeyValue.set("key", "value");
+
+    expect(await KeyValue.get("key")).toBe("value");
+  });
+
+  test('KeyValue.get("key") === "value-overrided"', async () => {
+    await KeyValue.set("key", "value");
+    await KeyValue.set("key", "value-overrided");
+
+    expect(await KeyValue.get("key")).toBe("value-overrided");
+  });
+});
+
+describe('Check complex value insertion and restitution', () => {
+  afterEach(async () => {
+    await KeyValueStore().truncate();
+  });
+
+  //
+  // Scalar types
+  //
+
+  test('boolean value', async () => {
+    await KeyValue.set("true", true);
+    await KeyValue.set("false", false);
+
+    expect(await KeyValue.get("true")).toBe(true);
+    expect(await KeyValue.get("false")).toBe(false);
+  });
+
+  test('number value', async () => {
+    await KeyValue.set("100", 100);
+    await KeyValue.set("-254", -254);
+
+    expect(await KeyValue.get("100")).toBe(100);
+    expect(await KeyValue.get("-254")).toBe(-254);
+  });
+
+  test('string value', async () => {
+    await KeyValue.set("string", 'string');
+
+    expect(await KeyValue.get("string")).toBe('string');
+  });
+
+  test('null value', async () => {
+    await KeyValue.set("null", null);
+
+    expect(await KeyValue.get("null")).toBe(null);
+  });
+
+  //
+  // Objects types
+  //
+
+  const SIMPLE_OBJECT = {
+    toto: "tata",
+  };
+  const COMPLEX_OBJECT = {
+    boolean: true,
+    number: 1,
+    string: 'string',
+    null: null,
+    array: [1, 2, 3],
+  };
+  const NESTED_OBJECT = {
+    level1: {
+      level2: {
+        ...COMPLEX_OBJECT,
+      },
+    },
+  };
+
+  test('simple objects value', async () => {
+    await KeyValue.set(`SIMPLE_OBJECT`, SIMPLE_OBJECT);
+
+    expect(await KeyValue.get(`SIMPLE_OBJECT`)).toEqual(SIMPLE_OBJECT);
+  });
+
+  test('complex objects value', async () => {
+    await KeyValue.set(`COMPLEX_OBJECT`, COMPLEX_OBJECT);
+
+    expect(await KeyValue.get(`COMPLEX_OBJECT`)).toEqual(COMPLEX_OBJECT);
+  });
+
+  test('complex objects value', async () => {
+    await KeyValue.set(`NESTED_OBJECT`, NESTED_OBJECT);
+
+    expect(await KeyValue.get(`NESTED_OBJECT`)).toEqual(NESTED_OBJECT);
+  });
+
+  //
+  // Array Types
+  //
+
+  const SIMPLE_ARRAY = [1, 2, 3];
+  const COMPLEX_ARRAY = [true, false, 1, 'string', null, {...NESTED_OBJECT}];
+  const NESTED_ARRAY = [1, [...SIMPLE_ARRAY], [[...COMPLEX_ARRAY]]];
+
+  test('simple array value', async () => {
+    await KeyValue.set(`SIMPLE_ARRAY`, SIMPLE_ARRAY);
+
+    expect(await KeyValue.get(`SIMPLE_ARRAY`)).toEqual(SIMPLE_ARRAY);
+  });
+
+  test('complex array value', async () => {
+    await KeyValue.set(`COMPLEX_ARRAY`, COMPLEX_ARRAY);
+
+    expect(await KeyValue.get(`COMPLEX_ARRAY`)).toEqual(COMPLEX_ARRAY);
+  });
+
+  test('complex array value', async () => {
+    await KeyValue.set(`NESTED_ARRAY`, NESTED_ARRAY);
+
+    expect(await KeyValue.get(`NESTED_ARRAY`)).toEqual(NESTED_ARRAY);
+  });
+});
+
+describe('check getters when not empty', () => {
+  beforeAll(async () => {
+    await KeyValue.set('key', 'value');
+    await KeyValue.set('last-epic-slugs', ['spirit-of-the-north-f58a66', 'the-captain']);
+    await KeyValue.set('last-gog-slug', 'tales_of_monkey_island');
+  });
+
+  afterAll(async () => {
+    await KeyValueStore().truncate();
+  });
+
+  test('.length() === 3', async () => {
+    expect(await KeyValue.length()).toBe(3);
+  });
+
+  test('.keys()', async () => {
+    expect(await KeyValue.keys()).toEqual(['key', 'last-epic-slugs', 'last-gog-slug']);
+  });
+
+  test('.values()', async () => {
+    expect(await KeyValue.values()).toEqual(['value', ['spirit-of-the-north-f58a66', 'the-captain'], 'tales_of_monkey_island']);
+  });
+
+  test('.entries()', async () => {
+    expect(await KeyValue.entries()).toEqual([
+      ['key', 'value'],
+      ['last-epic-slugs', ['spirit-of-the-north-f58a66', 'the-captain']],
+      ['last-gog-slug', 'tales_of_monkey_island'],
+    ]);
+  });
+
+  test('.all()', async () => {
+    expect(await KeyValue.all()).toEqual([
+      {key: 'key', value: 'value'},
+      {key: 'last-epic-slugs', value: ['spirit-of-the-north-f58a66', 'the-captain']},
+      {key: 'last-gog-slug', value: 'tales_of_monkey_island'},
+    ]);
+  });
+
+  test('.has()', async () => {
+    expect(await KeyValue.has("key")).toBe(true);
+    expect(await KeyValue.has("last-epic-slugs")).toBe(true);
+    expect(await KeyValue.has("last-gog-slug")).toBe(true);
+  });
+});
+
+describe('check dropping', () => {
+  beforeEach(async () => {
+    await KeyValue.set('key', 'value');
+    await KeyValue.set('last-epic-slugs', ['spirit-of-the-north-f58a66', 'the-captain']);
+    await KeyValue.set('last-gog-slug', 'tales_of_monkey_island');
+  });
+
+  afterEach(async () => {
+    await KeyValueStore().truncate();
+  });
+
+  test('.drop() inexistant key', async () => {
+    expect(await KeyValue.drop("inexistant")).toBe(0);
+  });
+
+  test('.drop() existent key', async () => {
+    expect(await KeyValue.drop("key")).toEqual(1);
+    expect(await KeyValue.length()).toBe(2);
+  });
+
+  test('.drop() existent key with json', async () => {
+    expect(await KeyValue.drop("last-epic-slugs")).toEqual(1);
+    expect(await KeyValue.length()).toBe(2);
+  });
+
+  test('.dropAll', async () => {
+    await KeyValue.dropAll();
+    expect(await KeyValue.length()).toBe(0);
+  });
+})

--- a/tests/database/KeyValue.spec.ts
+++ b/tests/database/KeyValue.spec.ts
@@ -33,12 +33,16 @@ describe('Check emptiness', () => {
   });
 
   test('KeyValue.has("donotexistkey") === false', async () => {
-    expect(await KeyValue.has("donotexistkey")).toEqual(false);
+    expect(await KeyValue.has("donotexistkey")).toBe(false);
   });
 
   test('KeyValue.get("donotexistkey") === undefined', async () => {
-    expect(await KeyValue.get("donotexistkey")).toEqual(undefined);
+    expect(await KeyValue.get("donotexistkey")).toBe(undefined);
   });
+
+  test('KeyValue.search("key") === []', async () => {
+    expect(await KeyValue.search("key")).toEqual([]);
+  })
 });
 
 describe('Check insertion', () => {
@@ -241,6 +245,41 @@ describe('check getters when not empty', () => {
     expect(await KeyValue.has("last-epic-slugs")).toBe(true);
     expect(await KeyValue.has("last-gog-slug")).toBe(true);
   });
+
+  test('.search("LAST", 0b01)', async () => {
+    expect(await KeyValue.search('LAST', 0b01)).toEqual([
+      {key: 'last-epic-slugs', value: ['spirit-of-the-north-f58a66', 'the-captain']},
+      {key: 'last-gog-slug', value: 'tales_of_monkey_island'},
+    ]);
+  });
+
+  test('.search("slug", 0b10)', async () => {
+    expect(await KeyValue.search('slug', 0b10)).toEqual([
+      {key: 'last-gog-slug', value: 'tales_of_monkey_island'},
+    ]);
+  });
+
+  test('.search("kEy")', async () => {
+    await KeyValue.set('LastKeyInserted', 'zbadurg');
+    await KeyValue.set('RandomK', Math.random() * 100);
+    await KeyValue.set('keywords', ['last', 'slug']);
+
+    expect(await KeyValue.search('kEy')).toEqual([
+      {key: 'key', value: 'value'},
+      {key: 'LastKeyInserted', value: 'zbadurg'},
+      {key: 'keywords', value: ['last', 'slug']},
+    ]);
+  });
+
+  test('.search with escaping', async () => {
+    await KeyValue.set('50% of 100', 50);
+    await KeyValue.set('_underlined_', '# title');
+
+    expect(await KeyValue.search('% of')).toEqual([{key: '50% of 100', value: 50}]);
+    expect(await KeyValue.search('ed_', 0b10)).toEqual([{key: '_underlined_', value: '# title'}]);
+    expect(await KeyValue.search('50%', 0b01)).toEqual([{key: '50% of 100', value: 50}]);
+    expect(await KeyValue.search('% of 100', 0b10)).toEqual([{key: '50% of 100', value: 50}]);
+  })
 });
 
 describe('check dropping', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "moduleResolution": "node",
     "module": "CommonJS",
     "esModuleInterop": true,
+    "allowJs": true,
     "sourceMap": true,
     "rootDir": "./",
     "baseUrl": "./",


### PR DESCRIPTION
Comme vue ici https://github.com/ES-Community/bot/issues/17, les futures changements d'infra permettent d'utiliser sqlite.

J'ai donc ajouté `knex.js` Query Builder et Migrator utilisé dans le framework web `Adonis.js`, je me suis dit que vu la maison, ce serai adapté. 😉 @RomainLanz 
Accompagné de la lib better-sqlite3.

Et histoire que ça puisse être utilisé rapidement :
- une première migration avec une table `kv`
- le boilercode + config knex
- une API `KeyValue` qui interagi avec la table `kv` pour faire un Datastore Key Value.
- une batterie de test pour l'API `KeyValue`

Ce datastore pourra être exploité facilement pour les cron Epic et Gog à l'avenir.

```
npm install
npx knex migrate:latest
```

https://knexjs.org/guide/migrations.html#migration-cli