### PR TITLE
fallback slug on offerMappings and catalogNs

### DIFF
--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -173,7 +173,7 @@ const oneDay = 1000 * 60 * 60 * 24;
  * @param now - Current date. Comes from cron schedule.
  * @param logger
  */
-async function getOfferedGames(
+export async function getOfferedGames(
   now: Date,
   logger: Logger,
 ): Promise<Game[] | null> {

--- a/tests/cron/EpicGames.spec.ts
+++ b/tests/cron/EpicGames.spec.ts
@@ -1,0 +1,52 @@
+import pino from 'pino';
+import {getOfferedGames} from '#src/crons/EpicGames';
+
+const logger = pino();
+const oneDay = 1000 * 60 * 60 * 24;
+
+test('getOfferedGames', async () => {
+  const dates = generateDate();
+  
+  let lastGames
+  for (const date of dates) {
+    const games = await getOfferedGames(date, logger);
+    expect(games === null || Array.isArray(games)).toBe(true);
+    
+    if (!games) continue;
+    
+    if (lastGames) {
+      if (lastGames.length >= games.length && lastGames.every(g => games.some(gg => g.title === gg.title))) {
+        continue;
+      }
+    }
+    lastGames = games
+    
+    logger.info({date, games}, 'found epic for date');
+    
+    for (const game of games) {
+      expect(game.title).toBeTruthy();
+      expect(typeof game.title).toBe('string');
+      
+      expect(game.link).toBeTruthy();
+      expect(typeof game.link).toBe('string');
+      
+      expect(game.description).toBeTruthy();
+      expect(typeof game.description).toBe('string');
+      
+      expect(game.discountStartDate instanceof Date).toBe(true);
+      expect(game.discountEndDate instanceof Date).toBe(true);
+      
+      expect(game.originalPrice).toBeTruthy();
+      expect(typeof game.originalPrice).toBe('string');
+    }
+  }
+});
+
+function generateDate(now = new Date()) {
+  const nowMs = now.getTime();
+  
+  return Array(7).fill(0)
+    .map((v, i) => -i) // days
+    .map(d => d * oneDay) // days in ms
+    .map(deltaMs => new Date(nowMs + deltaMs))
+}


### PR DESCRIPTION
add description
add banner

J'ai fait pas mal de reverse-engeenering pour voir ce qu'on pouvais faire.
J'ai trouvé cette URL https://store-site-backend-static-ipv4.ak.epicgames.com/freeGamesPromotions?locale=fr&country=FR&allowCountries=FR appelé depuis la page d'accueil

J'y ai trouvé les champs catalogNs et offerMappings qui avait le slug, alors que le productSlug était null.

Au passage j'ai rajouté la description et une bannière.

J'apprécierai que quelqu'un test, je suis sur un PC avec proxy d'entreprise, c'est galère de lancer des programmes node qui vont requêter l'exterieur.