### PR TITLE
Feature/refacto cron datastore

### DIFF
--- a/src/crons/CommitStrip.ts
+++ b/src/crons/CommitStrip.ts
@@ -16,10 +16,10 @@ export default new Cron({
 
     // vérifie le strip trouvé avec la dernière entrée
     const lastStrip = await KeyValue.get<number>('Last-Cron-CommitStrip');
-    const gameStoreIdentity = strip?.id ?? null;
-    if (lastStrip === gameStoreIdentity) return; // skip si identique
+    const stripStoreIdentity = strip?.id ?? null;
+    if (lastStrip === stripStoreIdentity) return; // skip si identique
 
-    await KeyValue.set('Last-Cron-CommitStrip', gameStoreIdentity); // met à jour sinon
+    await KeyValue.set('Last-Cron-CommitStrip', stripStoreIdentity); // met à jour sinon
 
     if (!strip) return; // skip si pas de strip
 

--- a/src/crons/CommitStrip.ts
+++ b/src/crons/CommitStrip.ts
@@ -3,7 +3,7 @@ import got from 'got';
 import { decode } from 'html-entities';
 
 import { Cron, findTextChannelByName } from '../framework';
-import { KeyValue } from '#src/database';
+import { KeyValue } from '../database';
 
 export default new Cron({
   enabled: true,
@@ -85,7 +85,7 @@ interface CommitStrip {
 async function getLastCommitStrip(): Promise<CommitStrip | null> {
   const { body: posts } = await got<WordPressPost[]>(
     'https://www.commitstrip.com/fr/wp-json/wp/v2/posts?per_page=1',
-    { responseType: 'json', rejectUnauthorized: false },
+    { responseType: 'json', https: { rejectUnauthorized: false } },
   );
 
   if (posts.length === 0) {

--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -3,6 +3,7 @@ import got from 'got';
 import { Logger } from 'pino';
 
 import { Cron, findTextChannelByName } from '../framework';
+import { KeyValue } from '#src/database';
 
 const dateFmtOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Europe/Paris',
@@ -17,17 +18,22 @@ export default new Cron({
   enabled: true,
   name: 'EpicGames',
   description:
-    'Vérifie tous les jours à 17h30 (Paris) si Epic Games offre un jeu (promotion gratuite) et alerte dans #jeux',
-  schedule: '30 17 * * *',
+    'Vérifie toutes les demi heures si Epic Games offre un jeu (promotion gratuite) et alerte dans #jeux',
+  schedule: '5,35 * * * *',
   async handle(context) {
     const games = await getOfferedGames(context.date, context.logger);
-    if (!games) {
-      return;
-    }
+
+    const rawLastResults = (await KeyValue.get('Last-Cron-Epic')) as string[];
+    const lastGames = new Set<string>(rawLastResults);
+    const gamesToNotify = games.filter((g) => !lastGames.has(g.id));
+    await KeyValue.set(
+      'Last-Cron-Epic',
+      games.map((g) => g.id),
+    );
 
     const channel = findTextChannelByName(context.client.channels, 'jeux');
 
-    for (const game of games) {
+    for (const game of gamesToNotify) {
       context.logger.info(`Found a new offered game (${game.title})`);
 
       const message = new MessageEmbed({ title: game.title, url: game.link });
@@ -62,6 +68,7 @@ interface EpicGamesProducts {
     Catalog: {
       searchStore: {
         elements: {
+          id: string;
           title: string;
           description: string;
           keyImages: {
@@ -107,6 +114,10 @@ interface EpicGamesProducts {
  */
 interface Game {
   /**
+   * Game id.
+   */
+  id: string;
+  /**
    * Game title.
    */
   title: string;
@@ -144,6 +155,7 @@ const OFFERED_GAMES_QUERY = `query searchStoreQuery($country: String!, $locale: 
   Catalog {
     searchStore(category: "games", country: $country, locale: $locale, freeGame: true, onSale: true, count: $count) {
       elements {
+        id
         title
         productSlug
         catalogNs { mappings { pageSlug, pageType } }
@@ -165,8 +177,6 @@ const OFFERED_GAMES_QUERY = `query searchStoreQuery($country: String!, $locale: 
   }
 }`;
 
-const oneDay = 1000 * 60 * 60 * 24;
-
 /**
  * Fetches offered games from the Epic Games GraphQL API. If there are any and they
  * were offered between the previous and current cron execution, returns them.
@@ -176,7 +186,7 @@ const oneDay = 1000 * 60 * 60 * 24;
 export async function getOfferedGames(
   now: Date,
   logger: Logger,
-): Promise<Game[] | null> {
+): Promise<Game[]> {
   const { body } = await got<EpicGamesProducts>(
     'https://www.epicgames.com/graphql',
     {
@@ -198,22 +208,21 @@ export async function getOfferedGames(
   const catalog = body.data.Catalog.searchStore;
 
   if (catalog.paging.total === 0) {
-    return null;
+    return [];
   }
 
   const nowTime = now.getTime();
 
   // Keep only the games that were offered in the last day.
-  const games = catalog.elements.filter((game) => {
-    const startDate = new Date(
-      game.price.lineOffers[0].appliedRules[0].startDate,
-    );
-    return nowTime - startDate.getTime() < oneDay;
-  });
+  const games = (catalog.elements ?? []).filter((game) => {
+    const rule = game.price.lineOffers[0].appliedRules[0];
+    const [startDate, endDate] = [
+      new Date(rule.startDate),
+      new Date(rule.endDate),
+    ];
 
-  if (games.length === 0) {
-    return null;
-  }
+    return startDate.getTime() < nowTime && nowTime < endDate.getTime();
+  });
 
   return games.map<Game>((game) => {
     const discount = game.price.lineOffers[0].appliedRules[0];
@@ -250,6 +259,7 @@ export async function getOfferedGames(
     banner = banner && encodeURI(banner);
 
     return {
+      id: game.id,
       title: game.title,
       description: game.description,
       link: link,

--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -3,7 +3,7 @@ import got from 'got';
 import { Logger } from 'pino';
 
 import { Cron, findTextChannelByName } from '../framework';
-import { KeyValue } from '#src/database';
+import { KeyValue } from '../database';
 
 const dateFmtOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Europe/Paris',

--- a/src/crons/EpicGames.ts
+++ b/src/crons/EpicGames.ts
@@ -23,7 +23,7 @@ export default new Cron({
   async handle(context) {
     const games = await getOfferedGames(context.date, context.logger);
 
-    const rawLastResults = (await KeyValue.get('Last-Cron-Epic')) as string[];
+    const rawLastResults = await KeyValue.get<string[]>('Last-Cron-Epic');
     const lastGames = new Set<string>(rawLastResults);
     const gamesToNotify = games.filter((g) => !lastGames.has(g.id));
     await KeyValue.set(

--- a/src/crons/GoG.ts
+++ b/src/crons/GoG.ts
@@ -4,7 +4,7 @@ import { Logger } from 'pino';
 
 import { Cron, findTextChannelByName } from '../framework';
 import { parse } from 'node-html-parser';
-import { KeyValue } from '#src/database';
+import { KeyValue } from '../database';
 
 const dateFmtOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Europe/Paris',

--- a/src/crons/GoG.ts
+++ b/src/crons/GoG.ts
@@ -4,6 +4,7 @@ import { Logger } from 'pino';
 
 import { Cron, findTextChannelByName } from '../framework';
 import { parse } from 'node-html-parser';
+import { KeyValue } from "#src/database";
 
 const dateFmtOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Europe/Paris',
@@ -18,14 +19,20 @@ export default new Cron({
   enabled: true,
   name: 'GoG',
   description:
-    'Vérifie tous les jours à 17h30 (Paris) si GoG offre un jeu (promotion gratuite) et alerte dans #jeux',
-  schedule: '30 17 * * *',
+    'Vérifie toutes les demi heures si GoG offre un jeu (promotion gratuite) et alerte dans #jeux',
+  schedule: '5,35 * * * *',
   // schedule: "* * * * *", // switch for testing
   async handle(context) {
     const game = await getOfferedGame(context.logger);
-    if (!game) {
-      return;
-    }
+    
+    // vérifie le jeu trouvé avec la dernière entrée
+    const lastGame = await KeyValue.get('Last-Cron-GOG') as unknown as string;
+    const gameStoreIdentity = game?.title ?? null;
+    if (lastGame === gameStoreIdentity) return; // skip si identique
+    
+    await KeyValue.set('Last-Cron-GOG', gameStoreIdentity) // met à jour sinon
+    
+    if (!game) return; // skip si pas de jeu
 
     const channel = findTextChannelByName(context.client.channels, 'jeux');
 
@@ -49,7 +56,7 @@ export default new Cron({
 });
 
 /**
- * Game information extracted from the GoG Game (prerendered HTML scrapping).
+ * Game information extracted from the GoG Game (pre-rendered HTML scrapping).
  */
 interface Game {
   title: string;
@@ -63,7 +70,7 @@ interface Game {
 }
 
 /**
- * Fetches offered games from the Epic Games GraphQL API. If there are any and they
+ * Fetches offered games from the Epic Games GraphQL API. If there are any, and they
  * were offered between the previous and current cron execution, returns them.
  * @param logger
  */

--- a/src/crons/GoG.ts
+++ b/src/crons/GoG.ts
@@ -4,7 +4,7 @@ import { Logger } from 'pino';
 
 import { Cron, findTextChannelByName } from '../framework';
 import { parse } from 'node-html-parser';
-import { KeyValue } from "#src/database";
+import { KeyValue } from '#src/database';
 
 const dateFmtOptions: Intl.DateTimeFormatOptions = {
   timeZone: 'Europe/Paris',
@@ -24,14 +24,14 @@ export default new Cron({
   // schedule: "* * * * *", // switch for testing
   async handle(context) {
     const game = await getOfferedGame(context.logger);
-    
+
     // vérifie le jeu trouvé avec la dernière entrée
-    const lastGame = await KeyValue.get('Last-Cron-GOG') as unknown as string;
+    const lastGame = await KeyValue.get<string>('Last-Cron-GOG');
     const gameStoreIdentity = game?.title ?? null;
     if (lastGame === gameStoreIdentity) return; // skip si identique
-    
-    await KeyValue.set('Last-Cron-GOG', gameStoreIdentity) // met à jour sinon
-    
+
+    await KeyValue.set('Last-Cron-GOG', gameStoreIdentity); // met à jour sinon
+
     if (!game) return; // skip si pas de jeu
 
     const channel = findTextChannelByName(context.client.channels, 'jeux');

--- a/src/database/KeyValue.ts
+++ b/src/database/KeyValue.ts
@@ -5,9 +5,9 @@ type JSONTypes = JSONScalar | JSONObject | JSONArray;
 type JSONObject = { [member: string]: JSONTypes };
 type JSONArray = JSONTypes[];
 
-export interface IKeyValue {
+export interface IKeyValue<T extends JSONTypes = JSONTypes> {
   key: string;
-  value: JSONTypes;
+  value: T;
 }
 
 export enum SearchFlag {
@@ -31,20 +31,20 @@ export const KeyValue = {
     return KeyValueStore<string[]>().select('key').pluck('key');
   },
 
-  values(): Promise<JSONTypes[]> {
+  values<T extends JSONTypes = JSONTypes>(): Promise<T[]> {
     return KeyValueStore<JSONTypes[]>()
       .select('value')
       .pluck('value')
       .then((values) => values.map((v: string) => JSON.parse(v)));
   },
 
-  entries(): Promise<[string, JSONTypes][]> {
+  entries<T extends JSONTypes = JSONTypes>(): Promise<[string, T][]> {
     return KeyValueStore<Iterable<IKeyValue>>()
       .select('key', 'value')
       .then((entries) => entries.map((kv) => [kv.key, JSON.parse(kv.value)]));
   },
 
-  all(): Promise<IKeyValue[]> {
+  all<T extends JSONTypes = JSONTypes>(): Promise<IKeyValue<T>[]> {
     return KeyValueStore<IKeyValue[]>()
       .select('key', 'value')
       .then((items) => {
@@ -64,7 +64,9 @@ export const KeyValue = {
       .then(Boolean);
   },
 
-  async get(key: string): Promise<JSONTypes | undefined> {
+  async get<T extends JSONTypes = JSONTypes>(
+    key: string,
+  ): Promise<T | undefined> {
     const item = await KeyValueStore<string>()
       .select('value')
       .where('key', key)
@@ -91,10 +93,10 @@ export const KeyValue = {
    * @param likeKey - case-insensitive
    * @param flag - a 2 binary mask. 0b10 for left %, 0b01 for right %, 0b11 for both
    */
-  search(
+  search<T extends JSONTypes = JSONTypes>(
     likeKey: string,
     flag: SearchFlag = SearchFlag.Contains,
-  ): Promise<IKeyValue[]> {
+  ): Promise<IKeyValue<T>[]> {
     const left = 0b10 & flag ? '%' : '';
     const right = 0b01 & flag ? '%' : '';
 

--- a/tests/cron/EpicGames.spec.ts
+++ b/tests/cron/EpicGames.spec.ts
@@ -10,7 +10,7 @@ test('getOfferedGames', async () => {
   let lastGames;
   for (const date of dates) {
     const games = await getOfferedGames(date, testLogger);
-    expect(games === null || Array.isArray(games)).toBe(true);
+    expect(Array.isArray(games)).toBe(true);
 
     if (!games) continue;
 
@@ -25,6 +25,9 @@ test('getOfferedGames', async () => {
     lastGames = games;
 
     for (const game of games) {
+      expect(game.id).toBeTruthy();
+      expect(typeof game.id).toBe('string');
+
       expect(game.title).toBeTruthy();
       expect(typeof game.title).toBe('string');
 


### PR DESCRIPTION
refacto cron.

Ce base maintenant sur ce qui est stocké en base plutôt que de tweak sur les dates pour éviter les notifs en doublons.

J'ai aussi assoupli le type de retour des getter de KeyValue en ajoutant un Parameter Generic