### PR TITLE
Verify if null before pass in JSON.parse

### DIFF
--- a/src/crons/GoG.ts
+++ b/src/crons/GoG.ts
@@ -112,9 +112,7 @@ async function getOfferedGame(logger: Logger): Promise<Game | null> {
   const gameHTML = parse(gameBody);
   if (!gameHTML) return null;
 
-  const ldJSON = gameHTML.querySelector(
-    'script[type="application/ld+json"]',
-  );
+  const ldJSON = gameHTML.querySelector('script[type="application/ld+json"]');
   const ldJSONNode = ldJSON?.innerHTML ?? null;
 
   const gameJSON = ldJSONNode ? JSON.parse(ldJSONNode) : null;

--- a/src/crons/GoG.ts
+++ b/src/crons/GoG.ts
@@ -112,10 +112,12 @@ async function getOfferedGame(logger: Logger): Promise<Game | null> {
   const gameHTML = parse(gameBody);
   if (!gameHTML) return null;
 
-  const ldJSONNode = gameHTML.querySelector(
+  const ldJSON = gameHTML.querySelector(
     'script[type="application/ld+json"]',
   );
-  const gameJSON = JSON.parse(ldJSONNode?.innerHTML ?? '');
+  const ldJSONNode = ldJSON?.innerHTML ?? null;
+
+  const gameJSON = ldJSONNode ? JSON.parse(ldJSONNode) : null;
   if (!gameJSON) return null;
 
   const description =


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/115161783/196832207-29d18396-3552-4fc6-8bc4-4914cf04093f.png)

Je vois cette erreur dans les logs du discord et je propose un petit fix.

L'erreur vient du fait que si ldJSONNode.innerHTML n'existe pas alors on passe un string vide à JSON.parse ce qui génère l'erreur.

En espérant que cela vous sera utile :) 