### PR TITLE
feat(cron): add work chronicles cron

### DIFF
--- a/src/crons/WorkChronicles.ts
+++ b/src/crons/WorkChronicles.ts
@@ -50,6 +50,9 @@ interface WordPressPost {
   content: {
     rendered: string;
   };
+  yoast_head_json?: {
+    og_image: Array<{ url: string }>;
+  };
 }
 
 /**
@@ -91,16 +94,20 @@ export async function getLastChronicle(): Promise<WorkChronicle | null> {
 
   const [chronicle] = posts;
 
-  const chronicleImageUrlReg = /src="([^"]+)"/;
-  const urlMatch = chronicleImageUrlReg.exec(chronicle.content.rendered);
-  if (!urlMatch) {
-    return null;
+  let imageUrl = chronicle.yoast_head_json?.og_image.at(0)?.url;
+  if (!imageUrl) {
+    const chronicleImageUrlReg = /src="([^"]+)"/;
+    const urlMatch = chronicleImageUrlReg.exec(chronicle.content.rendered);
+    if (!urlMatch) {
+      return null;
+    }
+    imageUrl = urlMatch[1];
   }
 
   return {
     id: chronicle.id,
     link: chronicle.link,
     title: chronicle.title.rendered,
-    imageUrl: urlMatch[1],
+    imageUrl,
   };
 }

--- a/src/crons/WorkChronicles.ts
+++ b/src/crons/WorkChronicles.ts
@@ -61,10 +61,6 @@ interface WorkChronicle {
    */
   id: number;
   /**
-   * Post date.
-   */
-  date: Date;
-  /**
    * Direct link to the post.
    */
   link: string;
@@ -94,7 +90,6 @@ export async function getLastChronicle(): Promise<WorkChronicle | null> {
   }
 
   const [chronicle] = posts;
-  const chronicleDate = new Date(chronicle.date_gmt + '.000Z');
 
   const chronicleImageUrlReg = /src="([^"]+)"/;
   const urlMatch = chronicleImageUrlReg.exec(chronicle.content.rendered);
@@ -104,7 +99,6 @@ export async function getLastChronicle(): Promise<WorkChronicle | null> {
 
   return {
     id: chronicle.id,
-    date: chronicleDate,
     link: chronicle.link,
     title: chronicle.title.rendered,
     imageUrl: urlMatch[1],

--- a/src/crons/WorkChronicles.ts
+++ b/src/crons/WorkChronicles.ts
@@ -1,0 +1,112 @@
+import { EmbedBuilder } from 'discord.js';
+import got from 'got';
+
+import { Cron, findTextChannelByName } from '../framework/index.js';
+import { KeyValue } from '../database/index.js';
+
+export default new Cron({
+  enabled: true,
+  name: 'WorkChronicles',
+  description:
+    'Vérifie toutes les 30 minutes si un nouveau comic Work Chronicles est sorti et le poste dans #gif',
+  schedule: '5,35 * * * *',
+  async handle(context) {
+    const chronicle = await getLastChronicle();
+
+    // vérifie le comic trouvé avec la dernière entrée
+    const lastChronicle = await KeyValue.get<number>('Last-Cron-WorkChronicle');
+    const chronicleStoreIdentity = chronicle?.id ?? null;
+    if (lastChronicle === chronicleStoreIdentity) return; // skip si identique
+
+    await KeyValue.set('Last-Cron-WorkChronicle', chronicleStoreIdentity); // met à jour sinon
+
+    if (!chronicle) return; // skip si pas de comic
+
+    context.logger.info(`Found a new Work Chronicle (${chronicle.id})`);
+
+    const channel = findTextChannelByName(context.client.channels, 'gif');
+
+    await channel.send({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle(chronicle.title)
+          .setURL(chronicle.link)
+          .setImage(chronicle.imageUrl),
+      ],
+    });
+  },
+});
+
+/**
+ * Subset of the fields returned by the WordPress Posts API.
+ */
+interface WordPressPost {
+  id: number;
+  date_gmt: string;
+  link: string;
+  title: {
+    rendered: string;
+  };
+  content: {
+    rendered: string;
+  };
+}
+
+/**
+ * Chronicle information extracted from the WordPress post.
+ */
+interface WorkChronicle {
+  /**
+   * Post ID.
+   */
+  id: number;
+  /**
+   * Post date.
+   */
+  date: Date;
+  /**
+   * Direct link to the post.
+   */
+  link: string;
+  /**
+   * Post title.
+   */
+  title: string;
+  /**
+   * URL of the chronicle image.
+   */
+  imageUrl: string;
+}
+
+/**
+ * Fetches the most recent post from the WordPress API. If there is one, and it
+ * was posted between the previous and current cron execution, returns it.
+ * Otherwise, or if the post does not contain any image URL, returns null.
+ */
+export async function getLastChronicle(): Promise<WorkChronicle | null> {
+  const { body: posts } = await got<WordPressPost[]>(
+    'https://workchronicles.com/wp-json/wp/v2/posts?per_page=1',
+    { responseType: 'json', https: { rejectUnauthorized: false } },
+  );
+
+  if (posts.length === 0) {
+    return null;
+  }
+
+  const [chronicle] = posts;
+  const chronicleDate = new Date(chronicle.date_gmt + '.000Z');
+
+  const chronicleImageUrlReg = /src="([^"]+)"/;
+  const urlMatch = chronicleImageUrlReg.exec(chronicle.content.rendered);
+  if (!urlMatch) {
+    return null;
+  }
+
+  return {
+    id: chronicle.id,
+    date: chronicleDate,
+    link: chronicle.link,
+    title: chronicle.title.rendered,
+    imageUrl: urlMatch[1],
+  };
+}

--- a/tests/cron/WorkChornicles.spec.ts
+++ b/tests/cron/WorkChornicles.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from 'vitest';
+
+import { getLastChronicle } from '../../src/crons/WorkChronicles.js';
+
+test('getLastChronicle', async () => {
+  const chronicle = await getLastChronicle();
+  if (!chronicle) return;
+
+  expect(chronicle.id).toBeTruthy();
+  expect(typeof chronicle.id).toBe('number');
+
+  expect(chronicle.link).toBeTruthy();
+  expect(typeof chronicle.link).toBe('string');
+
+  expect(chronicle.title).toBeTruthy();
+  expect(typeof chronicle.title).toBe('string');
+
+  expect(chronicle.imageUrl).toBeTruthy();
+  expect(typeof chronicle.imageUrl).toBe('string');
+});

--- a/tests/cron/XKCD.spec.ts
+++ b/tests/cron/XKCD.spec.ts
@@ -16,7 +16,7 @@ test('getLastXKCDStrip', async () => {
   expect(typeof strip.title).toBe('string');
 
   expect(strip.description).toBeTruthy();
-  expect(typeof strip.title).toBe('string');
+  expect(typeof strip.description).toBe('string');
 
   expect(strip.imageUrl).toBeTruthy();
   expect(typeof strip.imageUrl).toBe('string');


### PR DESCRIPTION
### Context

Ajout du cron pour les comics du site https://workchronicles.com/
Resolves https://github.com/ES-Community/bot/issues/85

### Implementation

- copié collé du cron de commitstrip vu que ce sont tous les deux des sites wordpress
- ajout de tests
- rename du fichier de tests pour XKCD
- fix d'un test case XKCD

Testé sur une copie du serveur Discord via le template et un bot perso.

### Screenshot

![SCR-20230930-slr](https://github.com/ES-Community/bot/assets/9216777/731cbd3d-2b4a-4b6f-ba4f-7bf2d0cc6423)